### PR TITLE
Fix class transformers loading transformable classes while transforming other classes

### DIFF
--- a/src/main/java/com/wildex999/patcher/EntityInjector.java
+++ b/src/main/java/com/wildex999/patcher/EntityInjector.java
@@ -1,13 +1,16 @@
 package com.wildex999.patcher;
 
-import com.wildex999.tickdynamic.TickDynamicMod;
 import com.wildex999.tickdynamic.listinject.EntityObject;
 import net.minecraft.launchwrapper.IClassTransformer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.objectweb.asm.*;
 
 //Inject EntityObject as a base for both Entity and TileEntity for further use
 
 public class EntityInjector implements IClassTransformer {
+
+	private static final Logger LOGGER = LogManager.getLogger();
 
 	@Override
 	public byte[] transform(String name, String transformedName,
@@ -15,7 +18,7 @@ public class EntityInjector implements IClassTransformer {
 
 		if (!transformedName.equals("net.minecraft.entity.Entity") && !transformedName.equals("net.minecraft.tileentity.TileEntity"))
 			return basicClass;
-		TickDynamicMod.logInfo("Entity Inject: " + transformedName);
+		LOGGER.info("Entity Inject: " + transformedName);
 
 		ClassReader cr = new ClassReader(basicClass);
 		ClassWriter cw = new ClassWriter(0);
@@ -38,7 +41,7 @@ public class EntityInjector implements IClassTransformer {
 		public void visit(int version, int access, String name,
 		                  String signature, String superName, String[] interfaces) {
 			if (!superName.equals("java/lang/Object")) {
-				TickDynamicMod.logWarn("WARNING: " + name + " already has a super class which will be overwritten: " + superName
+				LOGGER.warn("WARNING: " + name + " already has a super class which will be overwritten: " + superName
 						+ "\nThis means that some other mod might no longer work properly!");
 			}
 			super.visit(version, access + Opcodes.ACC_SUPER, name, signature, EntityObject.class.getName().replace('.', '/'), interfaces);

--- a/src/main/java/com/wildex999/tickdynamic/LoadingPlugin.java
+++ b/src/main/java/com/wildex999/tickdynamic/LoadingPlugin.java
@@ -1,8 +1,6 @@
 package com.wildex999.tickdynamic;
 
 import com.wildex999.patcher.EntityInjector;
-import com.wildex999.patcher.TransformerPatcher;
-import net.minecraft.launchwrapper.Launch;
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin;
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.SortingIndex;
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.TransformerExclusions;
@@ -16,13 +14,7 @@ public class LoadingPlugin implements IFMLLoadingPlugin {
 
 	@Override
 	public String[] getASMTransformerClass() {
-		boolean developmentEnvironment = (Boolean) Launch.blackboard.get("fml.deobfuscatedEnvironment");
-
-		//Only return the patcher if running in live environment, to allow for testing when running from eclipse/idea
-		if (!developmentEnvironment)
-			return new String[]{TransformerPatcher.class.getName(), EntityInjector.class.getName()};
-		else
-			return new String[]{EntityInjector.class.getName()};
+		return new String[]{EntityInjector.class.getName()};
 	}
 
 	@Override


### PR DESCRIPTION
Using the `TickDynamicMod` class for logging loads a bunch of other classes. This PR fixes this issue by adding a logger that is used exclusively by the `EntityInjector` class.
This PR also removes the `TransformerPatcher` class transformer from the list of transformers returned by `LoadingPlugin#getASMTransformerClass`. The `TransformerPatcher` doesn't seem to be used at all. Thus there is no reason to enable it since this might also cause issues similar to the `EntityInjector` loading the `TickDynamicMod` class.